### PR TITLE
Make RssFeedXML Public

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -127,5 +127,5 @@ func (r *Rss) FeedXml() interface{} {
 
 // return an XML-ready object for an RssFeed object
 func (r *RssFeed) FeedXml() interface{} {
-	return &rssFeedXml{Version: "2.0", Channel: r}
+	return &RssFeedXml{Version: "2.0", Channel: r}
 }


### PR DESCRIPTION
I wanted to use your types for Parsing XML feeds so I needed this one type to be opened.

Sorry for idiotic comment 
