### PR TITLE
Update rss date format to RFC822 per the spec.

### DIFF
--- a/feed_test.go
+++ b/feed_test.go
@@ -50,25 +50,25 @@ var rssOutput = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0">
     <description>discussion about tech, footie, photos</description>
     <copyright>This work is copyright © Benjamin Button</copyright>
     <managingEditor>jmoiron@jmoiron.net (Jason Moiron)</managingEditor>
-    <pubDate>2013-01-16T21:52:35-05:00</pubDate>
+    <pubDate>16 Jan 13 21:52 EST</pubDate>
     <item>
       <title>Limiting Concurrency in Go</title>
       <link>http://jmoiron.net/blog/limiting-concurrency-in-go/</link>
       <description>A discussion on controlled parallelism in golang</description>
       <author>Jason Moiron</author>
-      <pubDate>2013-01-16T21:52:35-05:00</pubDate>
+      <pubDate>16 Jan 13 21:52 EST</pubDate>
     </item>
     <item>
       <title>Logic-less Template Redux</title>
       <link>http://jmoiron.net/blog/logicless-template-redux/</link>
       <description>More thoughts on logicless templates</description>
-      <pubDate>2013-01-16T21:52:35-05:00</pubDate>
+      <pubDate>16 Jan 13 21:52 EST</pubDate>
     </item>
     <item>
       <title>Idiomatic Code Reuse in Go</title>
       <link>http://jmoiron.net/blog/idiomatic-code-reuse-in-go/</link>
       <description>How to use interfaces &lt;em&gt;effectively&lt;/em&gt;</description>
-      <pubDate>2013-01-16T21:52:35-05:00</pubDate>
+      <pubDate>16 Jan 13 21:52 EST</pubDate>
     </item>
   </channel>
 </rss>`

--- a/rss.go
+++ b/rss.go
@@ -90,7 +90,7 @@ func newRssItem(i *Item) *RssItem {
 		Link:        i.Link.Href,
 		Description: i.Description,
 		Guid:        i.Id,
-		PubDate:     anyTimeFormat(time.RFC3339, i.Created, i.Updated),
+		PubDate:     anyTimeFormat(time.RFC822, i.Created, i.Updated),
 	}
 	if i.Author != nil {
 		item.Author = i.Author.Name
@@ -100,8 +100,8 @@ func newRssItem(i *Item) *RssItem {
 
 // create a new RssFeed with a generic Feed struct's data
 func (r *Rss) RssFeed() *RssFeed {
-	pub := anyTimeFormat(time.RFC3339, r.Created, r.Updated)
-	build := anyTimeFormat(time.RFC3339, r.Updated)
+	pub := anyTimeFormat(time.RFC822, r.Created, r.Updated)
+	build := anyTimeFormat(time.RFC822, r.Updated)
 	author := r.Author.Email
 	if len(r.Author.Name) > 0 {
 		author = fmt.Sprintf("%s (%s)", r.Author.Email, r.Author.Name)


### PR DESCRIPTION
http://cyber.law.harvard.edu/rss/rss.html

"All date-times in RSS conform to the Date and Time Specification of RFC 822,
with the exception that the year may be expressed with two characters or four
characters (four preferred)."
