### PR TITLE
Add optional xmlns to AtomEntry

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -41,6 +41,7 @@ type AtomContributor struct {
 
 type AtomEntry struct {
 	XMLName     xml.Name `xml:"entry"`
+	Xmlns       string   `xml:"xmlns,attr,omitempty"`
 	Title       string   `xml:"title"`   // required
 	Updated     string   `xml:"updated"` // required
 	Id          string   `xml:"id"`      // required


### PR DESCRIPTION
This allows individual entries to be marshalled to XML with an xmlns. It's optional so entries in a feed don't get an xmlns of their own.

Without this change, if you try to marshal an individual entry it won't have an atom xmlns.
