### PR TITLE
Allow multiple links in atom feeds and entries

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -51,7 +51,8 @@ type AtomEntry struct {
 	Source      string `xml:"source,omitempty"`
 	Published   string `xml:"published,omitempty"`
 	Contributor *AtomContributor
-	Link        *AtomLink    // required if no child 'content' elements
+	Link        *AtomLink // required if no child 'content' elements
+	Links       []*AtomLink
 	Summary     *AtomSummary // required if content has src or content is base64
 	Author      *AtomAuthor  // required if feed lacks an author
 }
@@ -74,7 +75,8 @@ type AtomFeed struct {
 	Rights      string   `xml:"rights,omitempty"` // copyright used
 	Subtitle    string   `xml:"subtitle,omitempty"`
 	Link        *AtomLink
-	Author      *AtomAuthor // required 
+	Links       []*AtomLink
+	Author      *AtomAuthor // required
 	Contributor *AtomContributor
 	Entries     []*AtomEntry
 }

--- a/atom_test.go
+++ b/atom_test.go
@@ -1,0 +1,43 @@
+package feeds
+
+import "testing"
+
+var multipleLinksOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.w3.org/2005/Atom">
+  <title>jmoiron.net atom</title>
+  <id>http://jmoiron.net/atom</id>
+  <updated>2013-01-16T21:52:35-05:00</updated>
+  <link href="http://jmoiron.net/atom" rel="self"></link>
+  <link href="http://jmoiron.net/atom/1" rel="next-archive"></link>
+  <entry>
+    <title>Limiting Concurrency in Go</title>
+    <updated>2013-01-16T21:52:35-05:00</updated>
+    <id>tag:jmoiron.net,2013-01-16:/atom/limiting-concurrency-in-go/</id>
+    <link href="http://jmoiron.net/blog/limiting-concurrency-in-go/" rel="self"></link>
+    <link href="http://jmoiron.net/blog/limiting-concurrency-in-go.xml" rel="alternative"></link>
+  </entry>
+</feed>`
+
+func TestMultipleLinksInFeed(t *testing.T) {
+	feed := &AtomFeed{
+		Xmlns:   "http://www.w3.org/2005/Atom",
+		Id:      "http://jmoiron.net/atom",
+		Title:   "jmoiron.net atom",
+		Link:    &AtomLink{Href: "http://jmoiron.net/atom", Rel: "self"},
+		Links:   []*AtomLink{&AtomLink{Href: "http://jmoiron.net/atom/1", Rel: "next-archive"}},
+		Updated: "2013-01-16T21:52:35-05:00",
+		Entries: []*AtomEntry{
+			&AtomEntry{
+				Id:      "tag:jmoiron.net,2013-01-16:/atom/limiting-concurrency-in-go/",
+				Updated: "2013-01-16T21:52:35-05:00",
+				Title:   "Limiting Concurrency in Go",
+				Link:    &AtomLink{Href: "http://jmoiron.net/blog/limiting-concurrency-in-go/", Rel: "self"},
+				Links:   []*AtomLink{&AtomLink{Href: "http://jmoiron.net/blog/limiting-concurrency-in-go.xml", Rel: "alternative"}},
+			},
+		},
+	}
+	atom, _ := ToXML(feed)
+
+	if atom != multipleLinksOutput {
+		t.Errorf("Atom not what was expected.  Got:\n%s\n\nExpected:\n%s\n", atom, multipleLinksOutput)
+	}
+}


### PR DESCRIPTION
As per the Atom spec, [Section 4.1.1][1], it's possible to have multiple links for feeds and entries with varying rel values. For example: self, current, prev-archive, and next-archive.

This change adds an extra `Links` collection to the `AtomEntry` and `AtomFeed` structures. I left the existing `Link` in there for compatibility, but I'd prefer to remove it if possible. The changes are only applied to the Atom structures, and not RSS (or Feed/Item) due to RSS not using more than a single link.

  [1]: http://tools.ietf.org/html/rfc4287#section-4.1.1