### PR TITLE
Make Author example and test vet compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ func main() {
         Title:       "jmoiron.net blog",
         Link:        &feeds.Link{Href: "http://jmoiron.net/blog"},
         Description: "discussion about tech, footie, photos",
-        Author:      &feeds.Author{"Jason Moiron", "jmoiron@jmoiron.net"},
+        Author:      &feeds.Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
         Created:     now,
     }
 
@@ -37,7 +37,7 @@ func main() {
             Title:       "Limiting Concurrency in Go",
             Link:        &feeds.Link{Href: "http://jmoiron.net/blog/limiting-concurrency-in-go/"},
             Description: "A discussion on controlled parallelism in golang",
-            Author:      &feeds.Author{"Jason Moiron", "jmoiron@jmoiron.net"},
+            Author:      &feeds.Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
             Created:     now,
         },
         &feeds.Item{

--- a/doc.go
+++ b/doc.go
@@ -22,7 +22,7 @@ Create a Feed and some Items in that feed using the generic interfaces:
 		Title:       "jmoiron.net blog",
 		Link:        &Link{Href: "http://jmoiron.net/blog"},
 		Description: "discussion about tech, footie, photos",
-		Author:      &Author{"Jason Moiron", "jmoiron@jmoiron.net"},
+		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 		Created:     now,
 		Copyright:   "This work is copyright © Benjamin Button",
 	}
@@ -32,7 +32,7 @@ Create a Feed and some Items in that feed using the generic interfaces:
 			Title:       "Limiting Concurrency in Go",
 			Link:        &Link{Href: "http://jmoiron.net/blog/limiting-concurrency-in-go/"},
 			Description: "A discussion on controlled parallelism in golang",
-			Author:      &Author{"Jason Moiron", "jmoiron@jmoiron.net"},
+			Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 			Created:     now,
 		},
 		&Item{

--- a/feed_test.go
+++ b/feed_test.go
@@ -113,7 +113,7 @@ func TestFeed(t *testing.T) {
 		Title:       "jmoiron.net blog",
 		Link:        &Link{Href: "http://jmoiron.net/blog"},
 		Description: "discussion about tech, footie, photos",
-		Author:      &Author{"Jason Moiron", "jmoiron@jmoiron.net"},
+		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 		Created:     now,
 		Copyright:   "This work is copyright © Benjamin Button",
 	}
@@ -123,7 +123,7 @@ func TestFeed(t *testing.T) {
 			Title:       "Limiting Concurrency in Go",
 			Link:        &Link{Href: "http://jmoiron.net/blog/limiting-concurrency-in-go/"},
 			Description: "A discussion on controlled parallelism in golang",
-			Author:      &Author{"Jason Moiron", "jmoiron@jmoiron.net"},
+			Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 			Created:     now,
 		},
 		{


### PR DESCRIPTION
Using the example from the documentation will result in a warning for
unkeyed composite literals during a 'go vet' run