### PR TITLE
Omit Atom feed Author from xml when it is not specified.

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -78,7 +78,7 @@ type AtomFeed struct {
 	Rights      string   `xml:"rights,omitempty"` // copyright used
 	Subtitle    string   `xml:"subtitle,omitempty"`
 	Link        *AtomLink
-	Author      *AtomAuthor // required
+	Author      *AtomAuthor `xml:"author,omitempty"`
 	Contributor *AtomContributor
 	Entries     []*AtomEntry
 }
@@ -145,8 +145,6 @@ func (a *Atom) AtomFeed() *AtomFeed {
 	}
 	if a.Author != nil {
 		feed.Author = &AtomAuthor{AtomPerson: AtomPerson{Name: a.Author.Name, Email: a.Author.Email}}
-	} else {
-		feed.Author = &AtomAuthor{AtomPerson: AtomPerson{Name: "", Email: ""}}
 	}
 	for _, e := range a.Items {
 		feed.Entries = append(feed.Entries, newAtomEntry(e))


### PR DESCRIPTION
From what I can tell from the spec (https://tools.ietf.org/html/rfc4287), atom feed author is optional. The W3 Feed Validator (https://validator.w3.org/feed/) fails when feed author is empty.