### PR TITLE
Fix the usage to get access to the underlying objects in the document

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -57,9 +57,9 @@ From here, you can output Atom, RSS, or JSON Feed versions of this feed easily
 
 You can also get access to the underlying objects that feeds uses to export its XML
 
-	atomFeed := &Atom{feed}.AtomFeed()
-	rssFeed := &Rss{feed}.RssFeed()
-	jsonFeed := &JSON{feed}.JSONFeed()
+	atomFeed := (&Atom{Feed: feed}).AtomFeed()
+	rssFeed := (&Rss{Feed: feed}).RssFeed()
+	jsonFeed := (&JSON{Feed: feed}).JSONFeed()
 
 From here, you can modify or add each syndication's specific fields before outputting
 


### PR DESCRIPTION
1. wrap with brackets to determine the priority.
2. fix the warning "composite literal uses unkeyed fields"
