### PR TITLE
Add support for content tag in feeds

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -90,7 +90,13 @@ type Atom struct {
 func newAtomEntry(i *Item) *AtomEntry {
 	id := i.Id
 	// assume the description is html
-	c := &AtomContent{Content: i.Description, Type: "html"}
+	s := &AtomSummary{Content: i.Description, Type: "html"}
+
+	// if there's a content, assume it's html
+	var c *AtomContent
+	if len(i.Content) > 0 {
+		c = &AtomContent{Content: i.Content, Type: "html"}
+	}
 
 	if len(id) == 0 {
 		// if there's no id set, try to create one, either from data or just a uuid
@@ -120,6 +126,7 @@ func newAtomEntry(i *Item) *AtomEntry {
 		Content: c,
 		Id:      id,
 		Updated: anyTimeFormat(time.RFC3339, i.Updated, i.Created),
+		Summary: s,
 	}
 
 	if i.Enclosure != nil && link_rel != "enclosure" {

--- a/atom.go
+++ b/atom.go
@@ -92,12 +92,6 @@ func newAtomEntry(i *Item) *AtomEntry {
 	// assume the description is html
 	s := &AtomSummary{Content: i.Description, Type: "html"}
 
-	// if there's a content, assume it's html
-	var c *AtomContent
-	if len(i.Content) > 0 {
-		c = &AtomContent{Content: i.Content, Type: "html"}
-	}
-
 	if len(id) == 0 {
 		// if there's no id set, try to create one, either from data or just a uuid
 		if len(i.Link.Href) > 0 && (!i.Created.IsZero() || !i.Updated.IsZero()) {
@@ -123,10 +117,14 @@ func newAtomEntry(i *Item) *AtomEntry {
 	x := &AtomEntry{
 		Title:   i.Title,
 		Links:   []AtomLink{{Href: i.Link.Href, Rel: link_rel, Type: i.Link.Type}},
-		Content: c,
 		Id:      id,
 		Updated: anyTimeFormat(time.RFC3339, i.Updated, i.Created),
 		Summary: s,
+	}
+
+	// if there's a content, assume it's html
+	if len(i.Content) > 0 {
+		x.Content = &AtomContent{Content: i.Content, Type: "html"}
 	}
 
 	if i.Enclosure != nil && link_rel != "enclosure" {

--- a/feed.go
+++ b/feed.go
@@ -34,6 +34,7 @@ type Item struct {
 	Updated     time.Time
 	Created     time.Time
 	Enclosure   *Enclosure
+	Content     string
 }
 
 type Feed struct {

--- a/feed_test.go
+++ b/feed_test.go
@@ -21,8 +21,9 @@ var atomOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.
     <title>Limiting Concurrency in Go</title>
     <updated>2013-01-16T21:52:35-05:00</updated>
     <id>tag:jmoiron.net,2013-01-16:/blog/limiting-concurrency-in-go/</id>
-    <content type="html">A discussion on controlled parallelism in golang</content>
+    <content type="html">&lt;p&gt;Go&#39;s goroutines make it easy to make &lt;a href=&#34;http://collectiveidea.com/blog/archives/2012/12/03/playing-with-go-embarrassingly-parallel-scripts/&#34;&gt;embarrassingly parallel programs&lt;/a&gt;, but in many &amp;quot;real world&amp;quot; cases resources can be limited and attempting to do everything at once can exhaust your access to them.&lt;/p&gt;</content>
     <link href="http://jmoiron.net/blog/limiting-concurrency-in-go/" rel="alternate"></link>
+    <summary type="html">A discussion on controlled parallelism in golang</summary>
     <author>
       <name>Jason Moiron</name>
       <email>jmoiron@jmoiron.net</email>
@@ -32,31 +33,31 @@ var atomOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.
     <title>Logic-less Template Redux</title>
     <updated>2013-01-16T21:52:35-05:00</updated>
     <id>tag:jmoiron.net,2013-01-16:/blog/logicless-template-redux/</id>
-    <content type="html">More thoughts on logicless templates</content>
     <link href="http://jmoiron.net/blog/logicless-template-redux/" rel="alternate"></link>
+    <summary type="html">More thoughts on logicless templates</summary>
   </entry>
   <entry>
     <title>Idiomatic Code Reuse in Go</title>
     <updated>2013-01-16T21:52:35-05:00</updated>
     <id>tag:jmoiron.net,2013-01-16:/blog/idiomatic-code-reuse-in-go/</id>
-    <content type="html">How to use interfaces &lt;em&gt;effectively&lt;/em&gt;</content>
     <link href="http://jmoiron.net/blog/idiomatic-code-reuse-in-go/" rel="alternate"></link>
     <link href="http://example.com/cover.jpg" rel="enclosure" type="image/jpg" length="123456"></link>
+    <summary type="html">How to use interfaces &lt;em&gt;effectively&lt;/em&gt;</summary>
   </entry>
   <entry>
     <title>Never Gonna Give You Up Mp3</title>
     <updated>2013-01-16T21:52:35-05:00</updated>
     <id>tag:example.com,2013-01-16:/RickRoll.mp3</id>
-    <content type="html">Never gonna give you up - Never gonna let you down.</content>
     <link href="http://example.com/RickRoll.mp3" rel="alternate"></link>
     <link href="http://example.com/RickRoll.mp3" rel="enclosure" type="audio/mpeg" length="123456"></link>
+    <summary type="html">Never gonna give you up - Never gonna let you down.</summary>
   </entry>
   <entry>
     <title>String formatting in Go</title>
     <updated>2013-01-16T21:52:35-05:00</updated>
     <id>tag:example.com,2013-01-16:/strings</id>
-    <content type="html">How to use things like %s, %v, %d, etc.</content>
     <link href="http://example.com/strings" rel="alternate"></link>
+    <summary type="html">How to use things like %s, %v, %d, etc.</summary>
   </entry>
 </feed>`
 
@@ -74,6 +75,7 @@ var rssOutput = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0">
       <description>A discussion on controlled parallelism in golang</description>
       <author>Jason Moiron</author>
       <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
+      <content:encoded><![CDATA[<p>Go's goroutines make it easy to make <a href="http://collectiveidea.com/blog/archives/2012/12/03/playing-with-go-embarrassingly-parallel-scripts/">embarrassingly parallel programs</a>, but in many &quot;real world&quot; cases resources can be limited and attempting to do everything at once can exhaust your access to them.</p>]]></content:encoded>
     </item>
     <item>
       <title>Logic-less Template Redux</title>
@@ -179,6 +181,7 @@ func TestFeed(t *testing.T) {
 			Description: "A discussion on controlled parallelism in golang",
 			Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 			Created:     now,
+			Content:     `<p>Go's goroutines make it easy to make <a href="http://collectiveidea.com/blog/archives/2012/12/03/playing-with-go-embarrassingly-parallel-scripts/">embarrassingly parallel programs</a>, but in many &quot;real world&quot; cases resources can be limited and attempting to do everything at once can exhaust your access to them.</p>`,
 		},
 		{
 			Title:       "Logic-less Template Redux",

--- a/feed_test.go
+++ b/feed_test.go
@@ -61,7 +61,7 @@ var atomOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.
   </entry>
 </feed>`
 
-var rssOutput = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0">
+var rssOutput = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>jmoiron.net blog</title>
     <link>http://jmoiron.net/blog</link>
@@ -73,9 +73,9 @@ var rssOutput = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0">
       <title>Limiting Concurrency in Go</title>
       <link>http://jmoiron.net/blog/limiting-concurrency-in-go/</link>
       <description>A discussion on controlled parallelism in golang</description>
+      <content:encoded><![CDATA[<p>Go's goroutines make it easy to make <a href="http://collectiveidea.com/blog/archives/2012/12/03/playing-with-go-embarrassingly-parallel-scripts/">embarrassingly parallel programs</a>, but in many &quot;real world&quot; cases resources can be limited and attempting to do everything at once can exhaust your access to them.</p>]]></content:encoded>
       <author>Jason Moiron</author>
       <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
-      <content:encoded><![CDATA[<p>Go's goroutines make it easy to make <a href="http://collectiveidea.com/blog/archives/2012/12/03/playing-with-go-embarrassingly-parallel-scripts/">embarrassingly parallel programs</a>, but in many &quot;real world&quot; cases resources can be limited and attempting to do everything at once can exhaust your access to them.</p>]]></content:encoded>
     </item>
     <item>
       <title>Logic-less Template Redux</title>

--- a/rss.go
+++ b/rss.go
@@ -12,9 +12,10 @@ import (
 
 // private wrapper around the RssFeed which gives us the <rss>..</rss> xml
 type rssFeedXml struct {
-	XMLName xml.Name `xml:"rss"`
-	Version string   `xml:"version,attr"`
-	Channel *RssFeed
+	XMLName          xml.Name `xml:"rss"`
+	Version          string   `xml:"version,attr"`
+	ContentNamespace string   `xml:"xmlns:content,attr"`
+	Channel          *RssFeed
 }
 
 type RssContent struct {
@@ -68,14 +69,14 @@ type RssItem struct {
 	Title       string   `xml:"title"`       // required
 	Link        string   `xml:"link"`        // required
 	Description string   `xml:"description"` // required
-	Author      string   `xml:"author,omitempty"`
-	Category    string   `xml:"category,omitempty"`
-	Comments    string   `xml:"comments,omitempty"`
+	Content     *RssContent
+	Author      string `xml:"author,omitempty"`
+	Category    string `xml:"category,omitempty"`
+	Comments    string `xml:"comments,omitempty"`
 	Enclosure   *RssEnclosure
 	Guid        string `xml:"guid,omitempty"`    // Id used
 	PubDate     string `xml:"pubDate,omitempty"` // created or updated
 	Source      string `xml:"source,omitempty"`
-	Content     *RssContent
 }
 
 type RssEnclosure struct {
@@ -159,5 +160,9 @@ func (r *Rss) FeedXml() interface{} {
 
 // return an XML-ready object for an RssFeed object
 func (r *RssFeed) FeedXml() interface{} {
-	return &rssFeedXml{Version: "2.0", Channel: r}
+	return &rssFeedXml{
+		Version:          "2.0",
+		Channel:          r,
+		ContentNamespace: "http://purl.org/rss/1.0/modules/content/",
+	}
 }

--- a/rss.go
+++ b/rss.go
@@ -17,6 +17,11 @@ type rssFeedXml struct {
 	Channel *RssFeed
 }
 
+type RssContent struct {
+	XMLName xml.Name `xml:"content:encoded"`
+	Content string   `xml:",cdata"`
+}
+
 type RssImage struct {
 	XMLName xml.Name `xml:"image"`
 	Url     string   `xml:"url"`
@@ -70,6 +75,7 @@ type RssItem struct {
 	Guid        string `xml:"guid,omitempty"`    // Id used
 	PubDate     string `xml:"pubDate,omitempty"` // created or updated
 	Source      string `xml:"source,omitempty"`
+	Content     *RssContent
 }
 
 type RssEnclosure struct {
@@ -86,12 +92,19 @@ type Rss struct {
 
 // create a new RssItem with a generic Item struct's data
 func newRssItem(i *Item) *RssItem {
+	// append an encoded content if one is provided
+	var c *RssContent
+	if len(i.Content) > 0 {
+		c = &RssContent{Content: i.Content}
+	}
+
 	item := &RssItem{
 		Title:       i.Title,
 		Link:        i.Link.Href,
 		Description: i.Description,
 		Guid:        i.Id,
 		PubDate:     anyTimeFormat(time.RFC1123Z, i.Created, i.Updated),
+		Content:     c,
 	}
 	if i.Source != nil {
 		item.Source = i.Source.Href

--- a/rss.go
+++ b/rss.go
@@ -92,19 +92,15 @@ type Rss struct {
 
 // create a new RssItem with a generic Item struct's data
 func newRssItem(i *Item) *RssItem {
-	// append an encoded content if one is provided
-	var c *RssContent
-	if len(i.Content) > 0 {
-		c = &RssContent{Content: i.Content}
-	}
-
 	item := &RssItem{
 		Title:       i.Title,
 		Link:        i.Link.Href,
 		Description: i.Description,
 		Guid:        i.Id,
 		PubDate:     anyTimeFormat(time.RFC1123Z, i.Created, i.Updated),
-		Content:     c,
+	}
+	if len(i.Content) > 0 {
+		item.Content = &RssContent{Content: i.Content}
 	}
 	if i.Source != nil {
 		item.Source = i.Source.Href


### PR DESCRIPTION
Add support for `<content type="html">...</content>` (Atom) and `<content:encoded><![CDATA[ ... ]]></content:encoded>` (RSS) in feeds items. 

Also move post description to a `<summary type="html">...</summary>` tag in Atom feeds.