### PR TITLE
Use item content as JSON content_html

### DIFF
--- a/feed_test.go
+++ b/feed_test.go
@@ -119,6 +119,7 @@ var jsonOutput = `{
       "id": "",
       "url": "http://jmoiron.net/blog/limiting-concurrency-in-go/",
       "title": "Limiting Concurrency in Go",
+      "content_html": "\u003cp\u003eGo's goroutines make it easy to make \u003ca href=\"http://collectiveidea.com/blog/archives/2012/12/03/playing-with-go-embarrassingly-parallel-scripts/\"\u003eembarrassingly parallel programs\u003c/a\u003e, but in many \u0026quot;real world\u0026quot; cases resources can be limited and attempting to do everything at once can exhaust your access to them.\u003c/p\u003e",
       "summary": "A discussion on controlled parallelism in golang",
       "date_published": "2013-01-16T21:52:35-05:00",
       "author": {

--- a/json.go
+++ b/json.go
@@ -154,6 +154,8 @@ func newJSONItem(i *Item) *JSONItem {
 		Id:      i.Id,
 		Title:   i.Title,
 		Summary: i.Description,
+
+		ContentHTML: i.Content,
 	}
 
 	if i.Link != nil {


### PR DESCRIPTION
Fixes #45 

I went over a couple ways in my mind to do this, but this was dead simple.

It assumes HTML, this is in keeping with the library elsewhere. I could see wanting this library to let you specify a content type but that's a deeper investment than fixing this little bug.

https://github.com/gorilla/feeds/blob/96fc32f661059113abb411d3183972185b68e4a2/atom.go#L92-L93

https://github.com/gorilla/feeds/blob/96fc32f661059113abb411d3183972185b68e4a2/atom.go#L125-L128