### PR TITLE
Fix bug where date_modified empty if no created timestamp

### DIFF
--- a/json.go
+++ b/json.go
@@ -173,7 +173,7 @@ func newJSONItem(i *Item) *JSONItem {
 		item.PublishedDate = &i.Created
 	}
 	if !i.Updated.IsZero() {
-		item.ModifiedDate = &i.Created
+		item.ModifiedDate = &i.Updated
 	}
 	if i.Enclosure != nil && strings.HasPrefix(i.Enclosure.Type, "image/") {
 		item.Image = i.Enclosure.Url


### PR DESCRIPTION
Seems to be a copy paste error, otherwise the ModifiedDate is always empty if there's no CreatedDate.