### PR TITLE
Support plural categories in an entry

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -74,7 +74,7 @@ type AtomFeed struct {
 	Title       string   `xml:"title"`   // required
 	Id          string   `xml:"id"`      // required
 	Updated     string   `xml:"updated"` // required
-	Category    string   `xml:"category,omitempty"`
+	Categories  AtomCategories `xml:"category"`
 	Icon        string   `xml:"icon,omitempty"`
 	Logo        string   `xml:"logo,omitempty"`
 	Rights      string   `xml:"rights,omitempty"` // copyright used
@@ -148,7 +148,7 @@ func (a *Atom) AtomFeed() *AtomFeed {
 		Title:    a.Title,
 		Link:     &AtomLink{Href: a.Link.Href, Rel: a.Link.Rel},
 		Subtitle: a.Description,
-		Category: a.Category,
+		Categories: a.Categories,
 		Id:       a.Link.Href,
 		Updated:  updated,
 		Rights:   a.Copyright,

--- a/atom.go
+++ b/atom.go
@@ -39,13 +39,15 @@ type AtomContributor struct {
 	AtomPerson
 }
 
+type AtomCategories []string
+
 type AtomEntry struct {
 	XMLName     xml.Name `xml:"entry"`
 	Xmlns       string   `xml:"xmlns,attr,omitempty"`
 	Title       string   `xml:"title"`   // required
 	Updated     string   `xml:"updated"` // required
 	Id          string   `xml:"id"`      // required
-	Category    string   `xml:"category,omitempty"`
+	Categories  AtomCategories `xml:"category"`
 	Content     *AtomContent
 	Rights      string `xml:"rights,omitempty"`
 	Source      string `xml:"source,omitempty"`
@@ -115,11 +117,12 @@ func newAtomEntry(i *Item) *AtomEntry {
 		link_rel = "alternate"
 	}
 	x := &AtomEntry{
-		Title:   i.Title,
-		Links:   []AtomLink{{Href: i.Link.Href, Rel: link_rel, Type: i.Link.Type}},
-		Id:      id,
-		Updated: anyTimeFormat(time.RFC3339, i.Updated, i.Created),
-		Summary: s,
+		Title:      i.Title,
+		Links:      []AtomLink{{Href: i.Link.Href, Rel: link_rel, Type: i.Link.Type}},
+		Id:         id,
+		Categories: i.Categories,
+		Updated:    anyTimeFormat(time.RFC3339, i.Updated, i.Created),
+		Summary:    s,
 	}
 
 	// if there's a content, assume it's html
@@ -145,6 +148,7 @@ func (a *Atom) AtomFeed() *AtomFeed {
 		Title:    a.Title,
 		Link:     &AtomLink{Href: a.Link.Href, Rel: a.Link.Rel},
 		Subtitle: a.Description,
+		Category: a.Category,
 		Id:       a.Link.Href,
 		Updated:  updated,
 		Rights:   a.Copyright,

--- a/atom.go
+++ b/atom.go
@@ -42,11 +42,11 @@ type AtomContributor struct {
 type AtomCategories []string
 
 type AtomEntry struct {
-	XMLName     xml.Name `xml:"entry"`
-	Xmlns       string   `xml:"xmlns,attr,omitempty"`
-	Title       string   `xml:"title"`   // required
-	Updated     string   `xml:"updated"` // required
-	Id          string   `xml:"id"`      // required
+	XMLName     xml.Name       `xml:"entry"`
+	Xmlns       string         `xml:"xmlns,attr,omitempty"`
+	Title       string         `xml:"title"`   // required
+	Updated     string         `xml:"updated"` // required
+	Id          string         `xml:"id"`      // required
 	Categories  AtomCategories `xml:"category"`
 	Content     *AtomContent
 	Rights      string `xml:"rights,omitempty"`

--- a/atom.go
+++ b/atom.go
@@ -69,16 +69,16 @@ type AtomLink struct {
 }
 
 type AtomFeed struct {
-	XMLName     xml.Name `xml:"feed"`
-	Xmlns       string   `xml:"xmlns,attr"`
-	Title       string   `xml:"title"`   // required
-	Id          string   `xml:"id"`      // required
-	Updated     string   `xml:"updated"` // required
+	XMLName     xml.Name       `xml:"feed"`
+	Xmlns       string         `xml:"xmlns,attr"`
+	Title       string         `xml:"title"`   // required
+	Id          string         `xml:"id"`      // required
+	Updated     string         `xml:"updated"` // required
 	Categories  AtomCategories `xml:"category"`
-	Icon        string   `xml:"icon,omitempty"`
-	Logo        string   `xml:"logo,omitempty"`
-	Rights      string   `xml:"rights,omitempty"` // copyright used
-	Subtitle    string   `xml:"subtitle,omitempty"`
+	Icon        string         `xml:"icon,omitempty"`
+	Logo        string         `xml:"logo,omitempty"`
+	Rights      string         `xml:"rights,omitempty"` // copyright used
+	Subtitle    string         `xml:"subtitle,omitempty"`
 	Link        *AtomLink
 	Author      *AtomAuthor `xml:"author,omitempty"`
 	Contributor *AtomContributor
@@ -144,14 +144,14 @@ func newAtomEntry(i *Item) *AtomEntry {
 func (a *Atom) AtomFeed() *AtomFeed {
 	updated := anyTimeFormat(time.RFC3339, a.Updated, a.Created)
 	feed := &AtomFeed{
-		Xmlns:    ns,
-		Title:    a.Title,
-		Link:     &AtomLink{Href: a.Link.Href, Rel: a.Link.Rel},
-		Subtitle: a.Description,
+		Xmlns:      ns,
+		Title:      a.Title,
+		Link:       &AtomLink{Href: a.Link.Href, Rel: a.Link.Rel},
+		Subtitle:   a.Description,
 		Categories: a.Categories,
-		Id:       a.Link.Href,
-		Updated:  updated,
-		Rights:   a.Copyright,
+		Id:         a.Link.Href,
+		Updated:    updated,
+		Rights:     a.Copyright,
 	}
 	if a.Author != nil {
 		feed.Author = &AtomAuthor{AtomPerson: AtomPerson{Name: a.Author.Name, Email: a.Author.Email}}

--- a/feed.go
+++ b/feed.go
@@ -44,7 +44,7 @@ type Feed struct {
 	Link        *Link
 	Description string
 	Author      *Author
-	Category    string
+	Categories  []string
 	Updated     time.Time
 	Created     time.Time
 	Id          string

--- a/feed.go
+++ b/feed.go
@@ -36,6 +36,7 @@ type Item struct {
 	Created     time.Time
 	Enclosure   *Enclosure
 	Content     string
+	Categories  []string
 }
 
 type Feed struct {
@@ -43,6 +44,7 @@ type Feed struct {
 	Link        *Link
 	Description string
 	Author      *Author
+	Category    string
 	Updated     time.Time
 	Created     time.Time
 	Id          string

--- a/feed_test.go
+++ b/feed_test.go
@@ -21,6 +21,7 @@ var atomOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.
     <title>Limiting Concurrency in Go</title>
     <updated>2013-01-16T21:52:35-05:00</updated>
     <id>tag:jmoiron.net,2013-01-16:/blog/limiting-concurrency-in-go/</id>
+    <category>Programming</category>
     <content type="html">&lt;p&gt;Go&#39;s goroutines make it easy to make &lt;a href=&#34;http://collectiveidea.com/blog/archives/2012/12/03/playing-with-go-embarrassingly-parallel-scripts/&#34;&gt;embarrassingly parallel programs&lt;/a&gt;, but in many &amp;quot;real world&amp;quot; cases resources can be limited and attempting to do everything at once can exhaust your access to them.&lt;/p&gt;</content>
     <link href="http://jmoiron.net/blog/limiting-concurrency-in-go/" rel="alternate"></link>
     <summary type="html">A discussion on controlled parallelism in golang</summary>
@@ -33,6 +34,8 @@ var atomOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.
     <title>Logic-less Template Redux</title>
     <updated>2013-01-16T21:52:35-05:00</updated>
     <id>tag:jmoiron.net,2013-01-16:/blog/logicless-template-redux/</id>
+    <category>Programming</category>
+    <category>React</category>
     <link href="http://jmoiron.net/blog/logicless-template-redux/" rel="alternate"></link>
     <summary type="html">More thoughts on logicless templates</summary>
   </entry>
@@ -75,12 +78,15 @@ var rssOutput = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:
       <description>A discussion on controlled parallelism in golang</description>
       <content:encoded><![CDATA[<p>Go's goroutines make it easy to make <a href="http://collectiveidea.com/blog/archives/2012/12/03/playing-with-go-embarrassingly-parallel-scripts/">embarrassingly parallel programs</a>, but in many &quot;real world&quot; cases resources can be limited and attempting to do everything at once can exhaust your access to them.</p>]]></content:encoded>
       <author>Jason Moiron</author>
+      <category>Programming</category>
       <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
     </item>
     <item>
       <title>Logic-less Template Redux</title>
       <link>http://jmoiron.net/blog/logicless-template-redux/</link>
       <description>More thoughts on logicless templates</description>
+      <category>Programming</category>
+      <category>React</category>
       <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
     </item>
     <item>
@@ -182,12 +188,14 @@ func TestFeed(t *testing.T) {
 			Description: "A discussion on controlled parallelism in golang",
 			Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 			Created:     now,
+			Categories: []string{"Programming"},
 			Content:     `<p>Go's goroutines make it easy to make <a href="http://collectiveidea.com/blog/archives/2012/12/03/playing-with-go-embarrassingly-parallel-scripts/">embarrassingly parallel programs</a>, but in many &quot;real world&quot; cases resources can be limited and attempting to do everything at once can exhaust your access to them.</p>`,
 		},
 		{
 			Title:       "Logic-less Template Redux",
 			Link:        &Link{Href: "http://jmoiron.net/blog/logicless-template-redux/"},
 			Description: "More thoughts on logicless templates",
+			Categories:  []string{"Programming", "React"},
 			Created:     now,
 		},
 		{

--- a/feed_test.go
+++ b/feed_test.go
@@ -10,6 +10,8 @@ var atomOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.
   <title>jmoiron.net blog</title>
   <id>http://jmoiron.net/blog</id>
   <updated>2013-01-16T21:52:35-05:00</updated>
+  <category>Blog</category>
+  <category>Tech</category>
   <rights>This work is copyright © Benjamin Button</rights>
   <subtitle>discussion about tech, footie, photos</subtitle>
   <link href="http://jmoiron.net/blog"></link>
@@ -72,6 +74,8 @@ var rssOutput = `<?xml version="1.0" encoding="UTF-8"?><rss version="2.0" xmlns:
     <copyright>This work is copyright © Benjamin Button</copyright>
     <managingEditor>jmoiron@jmoiron.net (Jason Moiron)</managingEditor>
     <pubDate>Wed, 16 Jan 2013 21:52:35 -0500</pubDate>
+    <category>Blog</category>
+    <category>Tech</category>
     <item>
       <title>Limiting Concurrency in Go</title>
       <link>http://jmoiron.net/blog/limiting-concurrency-in-go/</link>
@@ -179,6 +183,7 @@ func TestFeed(t *testing.T) {
 		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 		Created:     now,
 		Copyright:   "This work is copyright © Benjamin Button",
+		Categories:  []string{"Blog", "Tech"},
 	}
 
 	feed.Items = []*Item{

--- a/feed_test.go
+++ b/feed_test.go
@@ -188,7 +188,7 @@ func TestFeed(t *testing.T) {
 			Description: "A discussion on controlled parallelism in golang",
 			Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 			Created:     now,
-			Categories: []string{"Programming"},
+			Categories:  []string{"Programming"},
 			Content:     `<p>Go's goroutines make it easy to make <a href="http://collectiveidea.com/blog/archives/2012/12/03/playing-with-go-embarrassingly-parallel-scripts/">embarrassingly parallel programs</a>, but in many &quot;real world&quot; cases resources can be limited and attempting to do everything at once can exhaust your access to them.</p>`,
 		},
 		{

--- a/rss.go
+++ b/rss.go
@@ -43,23 +43,23 @@ type RssTextInput struct {
 type RssCategories []string
 
 type RssFeed struct {
-	XMLName        xml.Name `xml:"channel"`
-	Title          string   `xml:"title"`       // required
-	Link           string   `xml:"link"`        // required
-	Description    string   `xml:"description"` // required
-	Language       string   `xml:"language,omitempty"`
-	Copyright      string   `xml:"copyright,omitempty"`
-	ManagingEditor string   `xml:"managingEditor,omitempty"` // Author used
-	WebMaster      string   `xml:"webMaster,omitempty"`
-	PubDate        string   `xml:"pubDate,omitempty"`       // created or updated
-	LastBuildDate  string   `xml:"lastBuildDate,omitempty"` // updated used
-	Generator      string   `xml:"generator,omitempty"`
-	Docs           string   `xml:"docs,omitempty"`
-	Cloud          string   `xml:"cloud,omitempty"`
-	Ttl            int      `xml:"ttl,omitempty"`
-	Rating         string   `xml:"rating,omitempty"`
-	SkipHours      string   `xml:"skipHours,omitempty"`
-	SkipDays       string   `xml:"skipDays,omitempty"`
+	XMLName        xml.Name      `xml:"channel"`
+	Title          string        `xml:"title"`       // required
+	Link           string        `xml:"link"`        // required
+	Description    string        `xml:"description"` // required
+	Language       string        `xml:"language,omitempty"`
+	Copyright      string        `xml:"copyright,omitempty"`
+	ManagingEditor string        `xml:"managingEditor,omitempty"` // Author used
+	WebMaster      string        `xml:"webMaster,omitempty"`
+	PubDate        string        `xml:"pubDate,omitempty"`       // created or updated
+	LastBuildDate  string        `xml:"lastBuildDate,omitempty"` // updated used
+	Generator      string        `xml:"generator,omitempty"`
+	Docs           string        `xml:"docs,omitempty"`
+	Cloud          string        `xml:"cloud,omitempty"`
+	Ttl            int           `xml:"ttl,omitempty"`
+	Rating         string        `xml:"rating,omitempty"`
+	SkipHours      string        `xml:"skipHours,omitempty"`
+	SkipDays       string        `xml:"skipDays,omitempty"`
 	Categories     RssCategories `xml:"category"`
 	Image          *RssImage
 	TextInput      *RssTextInput

--- a/rss.go
+++ b/rss.go
@@ -40,6 +40,8 @@ type RssTextInput struct {
 	Link        string   `xml:"link"`
 }
 
+type RssCategories []string
+
 type RssFeed struct {
 	XMLName        xml.Name `xml:"channel"`
 	Title          string   `xml:"title"`       // required
@@ -71,7 +73,7 @@ type RssItem struct {
 	Description string   `xml:"description"` // required
 	Content     *RssContent
 	Author      string `xml:"author,omitempty"`
-	Category    string `xml:"category,omitempty"`
+	Categories  RssCategories `xml:"category"`
 	Comments    string `xml:"comments,omitempty"`
 	Enclosure   *RssEnclosure
 	Guid        string `xml:"guid,omitempty"`    // Id used
@@ -99,6 +101,7 @@ func newRssItem(i *Item) *RssItem {
 		Description: i.Description,
 		Guid:        i.Id,
 		PubDate:     anyTimeFormat(time.RFC1123Z, i.Created, i.Updated),
+		Categories:  i.Categories,
 	}
 	if len(i.Content) > 0 {
 		item.Content = &RssContent{Content: i.Content}
@@ -142,6 +145,7 @@ func (r *Rss) RssFeed() *RssFeed {
 		ManagingEditor: author,
 		PubDate:        pub,
 		LastBuildDate:  build,
+		Category:       r.Category,
 		Copyright:      r.Copyright,
 		Image:          image,
 	}

--- a/rss.go
+++ b/rss.go
@@ -53,7 +53,6 @@ type RssFeed struct {
 	WebMaster      string   `xml:"webMaster,omitempty"`
 	PubDate        string   `xml:"pubDate,omitempty"`       // created or updated
 	LastBuildDate  string   `xml:"lastBuildDate,omitempty"` // updated used
-	Category       string   `xml:"category,omitempty"`
 	Generator      string   `xml:"generator,omitempty"`
 	Docs           string   `xml:"docs,omitempty"`
 	Cloud          string   `xml:"cloud,omitempty"`
@@ -61,6 +60,7 @@ type RssFeed struct {
 	Rating         string   `xml:"rating,omitempty"`
 	SkipHours      string   `xml:"skipHours,omitempty"`
 	SkipDays       string   `xml:"skipDays,omitempty"`
+	Categories     RssCategories `xml:"category"`
 	Image          *RssImage
 	TextInput      *RssTextInput
 	Items          []*RssItem
@@ -145,7 +145,7 @@ func (r *Rss) RssFeed() *RssFeed {
 		ManagingEditor: author,
 		PubDate:        pub,
 		LastBuildDate:  build,
-		Category:       r.Category,
+		Categories:     r.Categories,
 		Copyright:      r.Copyright,
 		Image:          image,
 	}

--- a/rss.go
+++ b/rss.go
@@ -72,9 +72,9 @@ type RssItem struct {
 	Link        string   `xml:"link"`        // required
 	Description string   `xml:"description"` // required
 	Content     *RssContent
-	Author      string `xml:"author,omitempty"`
+	Author      string        `xml:"author,omitempty"`
 	Categories  RssCategories `xml:"category"`
-	Comments    string `xml:"comments,omitempty"`
+	Comments    string        `xml:"comments,omitempty"`
 	Enclosure   *RssEnclosure
 	Guid        string `xml:"guid,omitempty"`    // Id used
 	PubDate     string `xml:"pubDate,omitempty"` // created or updated


### PR DESCRIPTION
There might be multiple categories for each RSS/Atom. This PR changes the Category to an array and outputs multiple category tags.

Ref: https://validator.w3.org/feed/docs/rss2.html
```
category | Specify one or more categories that the channel belongs to. Follows the same rules as the <item>-level category element. More info.
```