### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -158,12 +158,12 @@ func (a *Atom) AtomFeed() *AtomFeed {
 	return feed
 }
 
-// return an XML-Ready object for an Atom object
+// FeedXml returns an XML-Ready object for an Atom object
 func (a *Atom) FeedXml() interface{} {
 	return a.AtomFeed()
 }
 
-// return an XML-ready object for an AtomFeed object
+// FeedXml returns an XML-ready object for an AtomFeed object
 func (a *AtomFeed) FeedXml() interface{} {
 	return a
 }

--- a/feed.go
+++ b/feed.go
@@ -85,7 +85,7 @@ func ToXML(feed XmlFeed) (string, error) {
 	return s, nil
 }
 
-// Write a feed object (either a Feed, AtomFeed, or RssFeed) as XML into
+// WriteXML writes a feed object (either a Feed, AtomFeed, or RssFeed) as XML into
 // the writer. Returns an error if XML marshaling fails.
 func WriteXML(feed XmlFeed, w io.Writer) error {
 	x := feed.FeedXml()
@@ -104,7 +104,7 @@ func (f *Feed) ToAtom() (string, error) {
 	return ToXML(a)
 }
 
-// Writes an Atom representation of this feed to the writer.
+// WriteAtom writes an Atom representation of this feed to the writer.
 func (f *Feed) WriteAtom(w io.Writer) error {
 	return WriteXML(&Atom{f}, w)
 }
@@ -115,7 +115,7 @@ func (f *Feed) ToRss() (string, error) {
 	return ToXML(r)
 }
 
-// Writes an RSS representation of this feed to the writer.
+// WriteRss writes an RSS representation of this feed to the writer.
 func (f *Feed) WriteRss(w io.Writer) error {
 	return WriteXML(&Rss{f}, w)
 }

--- a/rss.go
+++ b/rss.go
@@ -151,14 +151,14 @@ func (r *Rss) RssFeed() *RssFeed {
 	return channel
 }
 
-// return an XML-Ready object for an Rss object
+// FeedXml returns an XML-Ready object for an Rss object
 func (r *Rss) FeedXml() interface{} {
 	// only generate version 2.0 feeds for now
 	return r.RssFeed().FeedXml()
 
 }
 
-// return an XML-ready object for an RssFeed object
+// FeedXml returns an XML-ready object for an RssFeed object
 func (r *RssFeed) FeedXml() interface{} {
 	return &RssFeedXml{
 		Version:          "2.0",


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._