### PR TITLE
 Enable  unmarshaling Links of AtomEntry

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -51,7 +51,7 @@ type AtomEntry struct {
 	Source      string `xml:"source,omitempty"`
 	Published   string `xml:"published,omitempty"`
 	Contributor *AtomContributor
-	Links       []AtomLink   // required if no child 'content' elements
+	Links       []AtomLink   `xml:"link,omitempty"` // required if no child 'content' elements
 	Summary     *AtomSummary // required if content has src or content is base64
 	Author      *AtomAuthor  // required if feed lacks an author
 }

--- a/consume_test.go
+++ b/consume_test.go
@@ -216,9 +216,11 @@ var testAtomFeedXML = AtomFeed{
 			Source:      "",
 			Published:   "",
 			Contributor: (*AtomContributor)(nil),
-			Links:       nil,
-			Summary:     (*AtomSummary)(nil),
-			Author:      (*AtomAuthor)(nil),
+			Links: []AtomLink{{
+				XMLName: xml.Name{Space: "", Local: "link"},
+				Href:    "http://example.com/test/1540941720"}},
+			Summary: (*AtomSummary)(nil),
+			Author:  (*AtomAuthor)(nil),
 		},
 		{
 			XMLName:     xml.Name{Space: "", Local: "entry"},
@@ -232,9 +234,11 @@ var testAtomFeedXML = AtomFeed{
 			Source:      "",
 			Published:   "",
 			Contributor: (*AtomContributor)(nil),
-			Links:       nil,
-			Summary:     (*AtomSummary)(nil),
-			Author:      (*AtomAuthor)(nil),
+			Links: []AtomLink{{
+				XMLName: xml.Name{Space: "", Local: "link"},
+				Href:    "http://example.com/test/1540941660"}},
+			Summary: (*AtomSummary)(nil),
+			Author:  (*AtomAuthor)(nil),
 		},
 		{
 			XMLName:     xml.Name{Space: "", Local: "entry"},
@@ -248,9 +252,11 @@ var testAtomFeedXML = AtomFeed{
 			Source:      "",
 			Published:   "",
 			Contributor: (*AtomContributor)(nil),
-			Links:       nil,
-			Summary:     (*AtomSummary)(nil),
-			Author:      (*AtomAuthor)(nil),
+			Links: []AtomLink{{
+				XMLName: xml.Name{Space: "", Local: "link"},
+				Href:    "http://example.com/test/1540941600"}},
+			Summary: (*AtomSummary)(nil),
+			Author:  (*AtomAuthor)(nil),
 		},
 		{
 			XMLName:     xml.Name{Space: "", Local: "entry"},
@@ -264,9 +270,11 @@ var testAtomFeedXML = AtomFeed{
 			Source:      "",
 			Published:   "",
 			Contributor: (*AtomContributor)(nil),
-			Links:       nil,
-			Summary:     (*AtomSummary)(nil),
-			Author:      (*AtomAuthor)(nil),
+			Links: []AtomLink{{
+				XMLName: xml.Name{Space: "", Local: "link"},
+				Href:    "http://example.com/test/1540941540"}},
+			Summary: (*AtomSummary)(nil),
+			Author:  (*AtomAuthor)(nil),
 		},
 		{
 			XMLName:     xml.Name{Space: "", Local: "entry"},
@@ -280,9 +288,11 @@ var testAtomFeedXML = AtomFeed{
 			Source:      "",
 			Published:   "",
 			Contributor: (*AtomContributor)(nil),
-			Links:       nil,
-			Summary:     (*AtomSummary)(nil),
-			Author:      (*AtomAuthor)(nil),
+			Links: []AtomLink{{
+				XMLName: xml.Name{Space: "", Local: "link"},
+				Href:    "http://example.com/test/1540941480"}},
+			Summary: (*AtomSummary)(nil),
+			Author:  (*AtomAuthor)(nil),
 		},
 		{
 			XMLName:     xml.Name{Space: "", Local: "entry"},
@@ -296,9 +306,11 @@ var testAtomFeedXML = AtomFeed{
 			Source:      "",
 			Published:   "",
 			Contributor: (*AtomContributor)(nil),
-			Links:       nil,
-			Summary:     (*AtomSummary)(nil),
-			Author:      (*AtomAuthor)(nil),
+			Links: []AtomLink{{
+				XMLName: xml.Name{Space: "", Local: "link"},
+				Href:    "http://example.com/test/1540941420"}},
+			Summary: (*AtomSummary)(nil),
+			Author:  (*AtomAuthor)(nil),
 		},
 		{
 			XMLName:     xml.Name{Space: "", Local: "entry"},
@@ -312,9 +324,11 @@ var testAtomFeedXML = AtomFeed{
 			Source:      "",
 			Published:   "",
 			Contributor: (*AtomContributor)(nil),
-			Links:       nil,
-			Summary:     (*AtomSummary)(nil),
-			Author:      (*AtomAuthor)(nil),
+			Links: []AtomLink{{
+				XMLName: xml.Name{Space: "", Local: "link"},
+				Href:    "http://example.com/test/1540941360"}},
+			Summary: (*AtomSummary)(nil),
+			Author:  (*AtomAuthor)(nil),
 		},
 		{
 			XMLName:     xml.Name{Space: "", Local: "entry"},
@@ -328,9 +342,11 @@ var testAtomFeedXML = AtomFeed{
 			Source:      "",
 			Published:   "",
 			Contributor: (*AtomContributor)(nil),
-			Links:       nil,
-			Summary:     (*AtomSummary)(nil),
-			Author:      (*AtomAuthor)(nil),
+			Links: []AtomLink{{
+				XMLName: xml.Name{Space: "", Local: "link"},
+				Href:    "http://example.com/test/1540941300"}},
+			Summary: (*AtomSummary)(nil),
+			Author:  (*AtomAuthor)(nil),
 		},
 		{
 			XMLName:     xml.Name{Space: "", Local: "entry"},
@@ -344,9 +360,11 @@ var testAtomFeedXML = AtomFeed{
 			Source:      "",
 			Published:   "",
 			Contributor: (*AtomContributor)(nil),
-			Links:       nil,
-			Summary:     (*AtomSummary)(nil),
-			Author:      (*AtomAuthor)(nil),
+			Links: []AtomLink{{
+				XMLName: xml.Name{Space: "", Local: "link"},
+				Href:    "http://example.com/test/1540941240"}},
+			Summary: (*AtomSummary)(nil),
+			Author:  (*AtomAuthor)(nil),
 		},
 		{
 			XMLName:     xml.Name{Space: "", Local: "entry"},
@@ -360,9 +378,11 @@ var testAtomFeedXML = AtomFeed{
 			Source:      "",
 			Published:   "",
 			Contributor: (*AtomContributor)(nil),
-			Links:       nil,
-			Summary:     (*AtomSummary)(nil),
-			Author:      (*AtomAuthor)(nil),
+			Links: []AtomLink{{
+				XMLName: xml.Name{Space: "", Local: "link"},
+				Href:    "http://example.com/test/1540941180"}},
+			Summary: (*AtomSummary)(nil),
+			Author:  (*AtomAuthor)(nil),
 		},
 	},
 }

--- a/test.atom
+++ b/test.atom
@@ -12,7 +12,7 @@
         <entry>
             <title><![CDATA[Lorem ipsum 2018-10-30T23:22:00+00:00]]></title>
             <description><![CDATA[Exercitation ut Lorem sint proident.]]></description>
-            <link>http://example.com/test/1540941720</link>
+            <link href="http://example.com/test/1540941720" />
             <guid isPermaLink="true">http://example.com/test/1540941720</guid>
             <dc:creator><![CDATA[John Smith]]></dc:creator>
             <pubDate>Tue, 30 Oct 2018 23:22:00 GMT</pubDate>
@@ -20,7 +20,7 @@
         <entry>
             <title><![CDATA[Lorem ipsum 2018-10-30T23:21:00+00:00]]></title>
             <description><![CDATA[Ea est do quis fugiat exercitation.]]></description>
-            <link>http://example.com/test/1540941660</link>
+            <link href="http://example.com/test/1540941660" />
             <guid isPermaLink="true">http://example.com/test/1540941660</guid>
             <dc:creator><![CDATA[John Smith]]></dc:creator>
             <pubDate>Tue, 30 Oct 2018 23:21:00 GMT</pubDate>
@@ -28,7 +28,7 @@
         <entry>
             <title><![CDATA[Lorem ipsum 2018-10-30T23:20:00+00:00]]></title>
             <description><![CDATA[Ipsum velit cillum ad laborum sit nulla exercitation consequat sint veniam culpa veniam voluptate incididunt.]]></description>
-            <link>http://example.com/test/1540941600</link>
+            <link href="http://example.com/test/1540941600" />
             <guid isPermaLink="true">http://example.com/test/1540941600</guid>
             <dc:creator><![CDATA[John Smith]]></dc:creator>
             <pubDate>Tue, 30 Oct 2018 23:20:00 GMT</pubDate>
@@ -36,7 +36,7 @@
         <entry>
             <title><![CDATA[Lorem ipsum 2018-10-30T23:19:00+00:00]]></title>
             <description><![CDATA[Ullamco pariatur aliqua consequat ea veniam id qui incididunt laborum.]]></description>
-            <link>http://example.com/test/1540941540</link>
+            <link href="http://example.com/test/1540941540" />
             <guid isPermaLink="true">http://example.com/test/1540941540</guid>
             <dc:creator><![CDATA[John Smith]]></dc:creator>
             <pubDate>Tue, 30 Oct 2018 23:19:00 GMT</pubDate>
@@ -44,7 +44,7 @@
         <entry>
             <title><![CDATA[Lorem ipsum 2018-10-30T23:18:00+00:00]]></title>
             <description><![CDATA[Velit proident aliquip aliquip anim mollit voluptate laboris voluptate et occaecat occaecat laboris ea nulla.]]></description>
-            <link>http://example.com/test/1540941480</link>
+            <link href="http://example.com/test/1540941480" />
             <guid isPermaLink="true">http://example.com/test/1540941480</guid>
             <dc:creator><![CDATA[John Smith]]></dc:creator>
             <pubDate>Tue, 30 Oct 2018 23:18:00 GMT</pubDate>
@@ -52,7 +52,7 @@
         <entry>
             <title><![CDATA[Lorem ipsum 2018-10-30T23:17:00+00:00]]></title>
             <description><![CDATA[Do in quis mollit consequat id in minim laborum sint exercitation laborum elit officia.]]></description>
-            <link>http://example.com/test/1540941420</link>
+            <link href="http://example.com/test/1540941420" />
             <guid isPermaLink="true">http://example.com/test/1540941420</guid>
             <dc:creator><![CDATA[John Smith]]></dc:creator>
             <pubDate>Tue, 30 Oct 2018 23:17:00 GMT</pubDate>
@@ -60,7 +60,7 @@
         <entry>
             <title><![CDATA[Lorem ipsum 2018-10-30T23:16:00+00:00]]></title>
             <description><![CDATA[Irure id sint ullamco Lorem magna consectetur officia adipisicing duis incididunt.]]></description>
-            <link>http://example.com/test/1540941360</link>
+            <link href="http://example.com/test/1540941360" />
             <guid isPermaLink="true">http://example.com/test/1540941360</guid>
             <dc:creator><![CDATA[John Smith]]></dc:creator>
             <pubDate>Tue, 30 Oct 2018 23:16:00 GMT</pubDate>
@@ -68,7 +68,7 @@
         <entry>
             <title><![CDATA[Lorem ipsum 2018-10-30T23:15:00+00:00]]></title>
             <description><![CDATA[Sunt anim excepteur esse nisi commodo culpa laborum exercitation ad anim ex elit.]]></description>
-            <link>http://example.com/test/1540941300</link>
+            <link href="http://example.com/test/1540941300" />
             <guid isPermaLink="true">http://example.com/test/1540941300</guid>
             <dc:creator><![CDATA[John Smith]]></dc:creator>
             <pubDate>Tue, 30 Oct 2018 23:15:00 GMT</pubDate>
@@ -76,7 +76,7 @@
         <entry>
             <title><![CDATA[Lorem ipsum 2018-10-30T23:14:00+00:00]]></title>
             <description><![CDATA[Excepteur aliquip fugiat ex labore nisi.]]></description>
-            <link>http://example.com/test/1540941240</link>
+            <link href="http://example.com/test/1540941240" />
             <guid isPermaLink="true">http://example.com/test/1540941240</guid>
             <dc:creator><![CDATA[John Smith]]></dc:creator>
             <pubDate>Tue, 30 Oct 2018 23:14:00 GMT</pubDate>
@@ -84,7 +84,7 @@
         <entry>
             <title><![CDATA[Lorem ipsum 2018-10-30T23:13:00+00:00]]></title>
             <description><![CDATA[Id proident adipisicing proident pariatur aute pariatur pariatur dolor dolor in voluptate dolor.]]></description>
-            <link>http://example.com/test/1540941180</link>
+            <link href="http://example.com/test/1540941180" />
             <guid isPermaLink="true">http://example.com/test/1540941180</guid>
             <dc:creator><![CDATA[John Smith]]></dc:creator>
             <pubDate>Tue, 30 Oct 2018 23:13:00 GMT</pubDate>


### PR DESCRIPTION
## Why
PR #59 makes us unmarshal atom feeds.
However, we can't unmarshal `Links` of `AtomEntry` because `Links` is not added  xml tag.

## What
Add xml tag for unmarshaling `Links` of `AtomEntry`