### PR TITLE
Fix travis ci script to support Go 1.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ matrix:
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
-  - go tool vet .
+  - go vet .
   - go test -v -race ./...


### PR DESCRIPTION
## Why
`go tool vet` command is no longer supported from version 1.12.

[Go 1.12 Release Notes](https://golang.org/doc/go1.12)

## What
Change travis ci script not to use `go tool vet`