### PR TITLE
fix JSONFeed Hubs

### DIFF
--- a/feed_test.go
+++ b/feed_test.go
@@ -509,6 +509,6 @@ func TestJSONHub(t *testing.T) {
 		t.Errorf("unexpected error encoding JSON: %v", err)
 	}
 	if json != jsonOutputHub {
-		t.Errorf("JSON not what was expected.  Got:\n%s\n\nExpected:\n%s\n", json, jsonOutputSorted)
+		t.Errorf("JSON not what was expected.  Got:\n%s\n\nExpected:\n%s\n", json, jsonOutputHub)
 	}
 }

--- a/feed_test.go
+++ b/feed_test.go
@@ -481,3 +481,34 @@ func TestFeedSorted(t *testing.T) {
 		t.Errorf("JSON not what was expected.  Got:\n||%s||\n\nExpected:\n||%s||\n", got, jsonOutputSorted)
 	}
 }
+
+var jsonOutputHub = `{
+  "version": "https://jsonfeed.org/version/1",
+  "title": "feed title",
+  "hubs": [
+    {
+      "type": "WebSub",
+      "url": "https://websub-hub.example"
+    }
+  ]
+}`
+
+func TestJSONHub(t *testing.T) {
+	feed := &JSONFeed{
+		Version: "https://jsonfeed.org/version/1",
+		Title:   "feed title",
+		Hubs: []*JSONHub{
+			&JSONHub{
+				Type: "WebSub",
+				Url:  "https://websub-hub.example",
+			},
+		},
+	}
+	json, err := feed.ToJSON()
+	if err != nil {
+		t.Errorf("unexpected error encoding JSON: %v", err)
+	}
+	if json != jsonOutputHub {
+		t.Errorf("JSON not what was expected.  Got:\n%s\n\nExpected:\n%s\n", json, jsonOutputSorted)
+	}
+}

--- a/json.go
+++ b/json.go
@@ -103,7 +103,7 @@ type JSONFeed struct {
 	Favicon     string      `json:"favicon,omitempty"`
 	Author      *JSONAuthor `json:"author,omitempty"`
 	Expired     *bool       `json:"expired,omitempty"`
-	Hubs        []*JSONItem `json:"hubs,omitempty"`
+	Hubs        []*JSONHub  `json:"hubs,omitempty"`
 	Items       []*JSONItem `json:"items,omitempty"`
 }
 


### PR DESCRIPTION
Fixes: `JSONFeed`.`Hubs` attribute was of type `[]*JSONItem` when it should have been `[]*JSONHub`.

**Summary of Changes**

1. Changed type of `JSONFeed`.`Hubs` from `[]*JSONItem` to `[]*JSONHub`.
