### PR TITLE
Add Language to Feed and 

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -50,6 +50,7 @@ type Feed struct {
 	Items       []*Item
 	Copyright   string
 	Image       *Image
+	Language    string
 }
 
 // add a new Item to a Feed

--- a/rss.go
+++ b/rss.go
@@ -144,6 +144,7 @@ func (r *Rss) RssFeed() *RssFeed {
 		LastBuildDate:  build,
 		Copyright:      r.Copyright,
 		Image:          image,
+		Language:       r.Language,
 	}
 	for _, i := range r.Items {
 		channel.Items = append(channel.Items, newRssItem(i))


### PR DESCRIPTION
**Summary of Changes**

1. Add a `Language` struct field to Feed
2. Set the existing RssFeed `Language` struct field to this newly added field during conversion
3. Don't do anything for Atom, since language is not a global setting

This is a two liner with no side effects, since Language was already covered in RssFeed. 

Why? RSS is useful for podcasts, and Apple Podcasts requires a Language field to be set. 
