### PR TITLE
add links

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -78,6 +78,7 @@ type AtomFeed struct {
 	Rights      string   `xml:"rights,omitempty"` // copyright used
 	Subtitle    string   `xml:"subtitle,omitempty"`
 	Link        *AtomLink
+	Links       []AtomLink
 	Author      *AtomAuthor `xml:"author,omitempty"`
 	Contributor *AtomContributor
 	Entries     []*AtomEntry `xml:"entry"`
@@ -148,6 +149,9 @@ func (a *Atom) AtomFeed() *AtomFeed {
 		Id:       a.Link.Href,
 		Updated:  updated,
 		Rights:   a.Copyright,
+	}
+	for _, l := range a.Links {
+		feed.Links = append(feed.Links, AtomLink{Href: l.Href, Rel: l.Rel})
 	}
 	if a.Author != nil {
 		feed.Author = &AtomAuthor{AtomPerson: AtomPerson{Name: a.Author.Name, Email: a.Author.Email}}

--- a/atom.go
+++ b/atom.go
@@ -158,6 +158,9 @@ func (a *Atom) AtomFeed() *AtomFeed {
 	if a.Author != nil {
 		feed.Author = &AtomAuthor{AtomPerson: AtomPerson{Name: a.Author.Name, Email: a.Author.Email}}
 	}
+	for _, l := range a.Links {
+		feed.Links = append(feed.Links, AtomLink{Href: l.Href, Rel: l.Rel})
+	}
 	for _, e := range a.Items {
 		feed.Entries = append(feed.Entries, newAtomEntry(e))
 	}

--- a/atom.go
+++ b/atom.go
@@ -44,7 +44,8 @@ type AtomEntry struct {
 	Xmlns       string   `xml:"xmlns,attr,omitempty"`
 	Title       string   `xml:"title"`   // required
 	Updated     string   `xml:"updated"` // required
-	Id          string   `xml:"id"`      // required
+	Created     string   `xml:"created"`
+	Id          string   `xml:"id"` // required
 	Category    string   `xml:"category,omitempty"`
 	Content     *AtomContent
 	Rights      string `xml:"rights,omitempty"`
@@ -72,6 +73,7 @@ type AtomFeed struct {
 	Title       string   `xml:"title"`   // required
 	Id          string   `xml:"id"`      // required
 	Updated     string   `xml:"updated"` // required
+	Created     string   `xml:"created"` // required
 	Category    string   `xml:"category,omitempty"`
 	Icon        string   `xml:"icon,omitempty"`
 	Logo        string   `xml:"logo,omitempty"`
@@ -120,6 +122,7 @@ func newAtomEntry(i *Item) *AtomEntry {
 		Links:   []AtomLink{{Href: i.Link.Href, Rel: link_rel, Type: i.Link.Type}},
 		Id:      id,
 		Updated: anyTimeFormat(time.RFC3339, i.Updated, i.Created),
+		Created: anyTimeFormat(time.RFC3339, i.Created),
 		Summary: s,
 	}
 
@@ -141,6 +144,7 @@ func newAtomEntry(i *Item) *AtomEntry {
 // create a new AtomFeed with a generic Feed struct's data
 func (a *Atom) AtomFeed() *AtomFeed {
 	updated := anyTimeFormat(time.RFC3339, a.Updated, a.Created)
+	created := anyTimeFormat(time.RFC3339, a.Created)
 	feed := &AtomFeed{
 		Xmlns:    ns,
 		Title:    a.Title,
@@ -148,10 +152,8 @@ func (a *Atom) AtomFeed() *AtomFeed {
 		Subtitle: a.Description,
 		Id:       a.Link.Href,
 		Updated:  updated,
+		Created:  created,
 		Rights:   a.Copyright,
-	}
-	for _, l := range a.Links {
-		feed.Links = append(feed.Links, AtomLink{Href: l.Href, Rel: l.Rel})
 	}
 	if a.Author != nil {
 		feed.Author = &AtomAuthor{AtomPerson: AtomPerson{Name: a.Author.Name, Email: a.Author.Email}}

--- a/feed.go
+++ b/feed.go
@@ -41,6 +41,7 @@ type Item struct {
 type Feed struct {
 	Title       string
 	Link        *Link
+	Links       []Link
 	Description string
 	Author      *Author
 	Updated     time.Time

--- a/feed_test.go
+++ b/feed_test.go
@@ -14,7 +14,7 @@ var atomOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.
   <subtitle>discussion about tech, footie, photos</subtitle>
   <link href="http://jmoiron.net/blog"></link>
   <link href="http://jmoiron.net/blog/first" rel="First"></link>
-  <link href="http://jmoiron.net/blog/last" rel="Last"></link>
+  <link href="http://jmoiron.net/blog/next" rel="Next"></link>
   <author>
     <name>Jason Moiron</name>
     <email>jmoiron@jmoiron.net</email>
@@ -113,6 +113,7 @@ var jsonOutput = `{
   "title": "jmoiron.net blog",
   "home_page_url": "http://jmoiron.net/blog",
   "description": "discussion about tech, footie, photos",
+  "next_url": "http://jmoiron.net/blog/next",
   "author": {
     "name": "Jason Moiron"
   },
@@ -173,7 +174,7 @@ func TestFeed(t *testing.T) {
 		Link:  &Link{Href: "http://jmoiron.net/blog"},
 		Links: []Link{
 			Link{Href: "http://jmoiron.net/blog/first", Rel: "First"},
-			Link{Href: "http://jmoiron.net/blog/last", Rel: "Last"},
+			Link{Href: "http://jmoiron.net/blog/next", Rel: "Next"},
 		},
 		Description: "discussion about tech, footie, photos",
 		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
@@ -271,7 +272,7 @@ var atomOutputSorted = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http:
   <subtitle>discussion about tech, footie, photos</subtitle>
   <link href="http://jmoiron.net/blog"></link>
   <link href="http://jmoiron.net/blog/first" rel="First"></link>
-  <link href="http://jmoiron.net/blog/last" rel="Last"></link>
+  <link href="http://jmoiron.net/blog/next" rel="Next"></link>
   <author>
     <name>Jason Moiron</name>
     <email>jmoiron@jmoiron.net</email>
@@ -359,6 +360,7 @@ var jsonOutputSorted = `{
   "title": "jmoiron.net blog",
   "home_page_url": "http://jmoiron.net/blog",
   "description": "discussion about tech, footie, photos",
+  "next_url": "http://jmoiron.net/blog/next",
   "author": {
     "name": "Jason Moiron"
   },
@@ -409,7 +411,7 @@ func TestFeedSorted(t *testing.T) {
 		Link:  &Link{Href: "http://jmoiron.net/blog"},
 		Links: []Link{
 			Link{Href: "http://jmoiron.net/blog/first", Rel: "First"},
-			Link{Href: "http://jmoiron.net/blog/last", Rel: "Last"},
+			Link{Href: "http://jmoiron.net/blog/next", Rel: "Next"},
 		},
 		Description: "discussion about tech, footie, photos",
 		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},

--- a/feed_test.go
+++ b/feed_test.go
@@ -13,6 +13,8 @@ var atomOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.
   <rights>This work is copyright © Benjamin Button</rights>
   <subtitle>discussion about tech, footie, photos</subtitle>
   <link href="http://jmoiron.net/blog"></link>
+  <link href="http://jmoiron.net/blog/first" rel="First"></link>
+  <link href="http://jmoiron.net/blog/last" rel="Last"></link>
   <author>
     <name>Jason Moiron</name>
     <email>jmoiron@jmoiron.net</email>
@@ -167,8 +169,12 @@ func TestFeed(t *testing.T) {
 	now = now.In(tz)
 
 	feed := &Feed{
-		Title:       "jmoiron.net blog",
-		Link:        &Link{Href: "http://jmoiron.net/blog"},
+		Title: "jmoiron.net blog",
+		Link:  &Link{Href: "http://jmoiron.net/blog"},
+		Links: []Link{
+			Link{Href: "http://jmoiron.net/blog/first", Rel: "First"},
+			Link{Href: "http://jmoiron.net/blog/last", Rel: "Last"},
+		},
 		Description: "discussion about tech, footie, photos",
 		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 		Created:     now,
@@ -264,6 +270,8 @@ var atomOutputSorted = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http:
   <rights>This work is copyright © Benjamin Button</rights>
   <subtitle>discussion about tech, footie, photos</subtitle>
   <link href="http://jmoiron.net/blog"></link>
+  <link href="http://jmoiron.net/blog/first" rel="First"></link>
+  <link href="http://jmoiron.net/blog/last" rel="Last"></link>
   <author>
     <name>Jason Moiron</name>
     <email>jmoiron@jmoiron.net</email>
@@ -397,8 +405,12 @@ func TestFeedSorted(t *testing.T) {
 	now = now.In(tz)
 
 	feed := &Feed{
-		Title:       "jmoiron.net blog",
-		Link:        &Link{Href: "http://jmoiron.net/blog"},
+		Title: "jmoiron.net blog",
+		Link:  &Link{Href: "http://jmoiron.net/blog"},
+		Links: []Link{
+			Link{Href: "http://jmoiron.net/blog/first", Rel: "First"},
+			Link{Href: "http://jmoiron.net/blog/last", Rel: "Last"},
+		},
 		Description: "discussion about tech, footie, photos",
 		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 		Created:     now,

--- a/json.go
+++ b/json.go
@@ -16,6 +16,14 @@ type JSONAuthor struct {
 	Avatar string `json:"avatar,omitempty"`
 }
 
+// JSONLinks represent the links as described in RFC5005 for Atom feeds
+type JSONLinks struct {
+	First    string `json:"first,omitempty"`
+	Last     string `json:"last,omitempty"`
+	Previous string `json:"previous,omitempty"`
+	Next     string `json:"next,omitempty"`
+}
+
 // JSONAttachment represents a related resource. Podcasts, for instance, would
 // include an attachment that’s an audio or video file.
 type JSONAttachment struct {
@@ -98,7 +106,7 @@ type JSONFeed struct {
 	FeedUrl     string      `json:"feed_url,omitempty"`
 	Description string      `json:"description,omitempty"`
 	UserComment string      `json:"user_comment,omitempty"`
-	NextUrl     string      `json:"next_url,omitempty"`
+	Links       *JSONLinks  `json:"links,omitempty"`
 	Icon        string      `json:"icon,omitempty"`
 	Favicon     string      `json:"favicon,omitempty"`
 	Author      *JSONAuthor `json:"author,omitempty"`
@@ -143,9 +151,20 @@ func (f *JSON) JSONFeed() *JSONFeed {
 			Name: f.Author.Name,
 		}
 	}
+	feed.Links = &JSONLinks{}
 	for _, l := range f.Links {
-		if strings.ToLower(l.Rel) == "next" {
-			feed.NextUrl = l.Href
+		switch strings.ToLower(l.Rel) {
+		case "next":
+			/* code */
+			feed.Links.Next = l.Href
+		case "previous":
+			feed.Links.Previous = l.Href
+		case "first":
+			feed.Links.First = l.Href
+		case "last":
+			feed.Links.Last = l.Href
+		default:
+			continue
 		}
 	}
 	for _, e := range f.Items {

--- a/json.go
+++ b/json.go
@@ -143,6 +143,11 @@ func (f *JSON) JSONFeed() *JSONFeed {
 			Name: f.Author.Name,
 		}
 	}
+	for _, l := range f.Links {
+		if strings.ToLower(l.Rel) == "next" {
+			feed.NextUrl = l.Href
+		}
+	}
 	for _, e := range f.Items {
 		feed.Items = append(feed.Items, newJSONItem(e))
 	}

--- a/json.go
+++ b/json.go
@@ -16,12 +16,10 @@ type JSONAuthor struct {
 	Avatar string `json:"avatar,omitempty"`
 }
 
-// JSONLinks represent the links as described in RFC5005 for Atom feeds
-type JSONLinks struct {
-	First    string `json:"first,omitempty"`
-	Last     string `json:"last,omitempty"`
-	Previous string `json:"previous,omitempty"`
-	Next     string `json:"next,omitempty"`
+// JSONLink represent the link as wanted by eminfra
+type JSONLink struct {
+	Rel  string `json:"rel"`
+	Href string `json:"href"`
 }
 
 // JSONAttachment represents a related resource. Podcasts, for instance, would
@@ -106,7 +104,7 @@ type JSONFeed struct {
 	FeedUrl     string      `json:"feed_url,omitempty"`
 	Description string      `json:"description,omitempty"`
 	UserComment string      `json:"user_comment,omitempty"`
-	Links       *JSONLinks  `json:"links,omitempty"`
+	Links       []*JSONLink `json:"links,omitempty"`
 	Icon        string      `json:"icon,omitempty"`
 	Favicon     string      `json:"favicon,omitempty"`
 	Author      *JSONAuthor `json:"author,omitempty"`
@@ -151,21 +149,8 @@ func (f *JSON) JSONFeed() *JSONFeed {
 			Name: f.Author.Name,
 		}
 	}
-	feed.Links = &JSONLinks{}
 	for _, l := range f.Links {
-		switch strings.ToLower(l.Rel) {
-		case "next":
-			/* code */
-			feed.Links.Next = l.Href
-		case "previous":
-			feed.Links.Previous = l.Href
-		case "first":
-			feed.Links.First = l.Href
-		case "last":
-			feed.Links.Last = l.Href
-		default:
-			continue
-		}
+		feed.Links = append(feed.Links, &JSONLink{Rel: l.Rel, Href: l.Href})
 	}
 	for _, e := range f.Items {
 		feed.Items = append(feed.Items, newJSONItem(e))


### PR DESCRIPTION
Fixes #

**Summary of Changes**

1. Add possibility to put multiple links into an atom feed. That allows to conform to RFC5005 for example. https://tools.ietf.org/html/rfc5005#section-3

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!

