### PR TITLE
[bug] RSS Item link should be optional

### DIFF
--- a/rss.go
+++ b/rss.go
@@ -95,10 +95,12 @@ type Rss struct {
 func newRssItem(i *Item) *RssItem {
 	item := &RssItem{
 		Title:       i.Title,
-		Link:        i.Link.Href,
 		Description: i.Description,
 		Guid:        i.Id,
 		PubDate:     anyTimeFormat(time.RFC1123Z, i.Created, i.Updated),
+	}
+	if i.Link != nil {
+		item.Link = i.Link.Href
 	}
 	if len(i.Content) > 0 {
 		item.Content = &RssContent{Content: i.Content}


### PR DESCRIPTION
According to RSS specification the `<link>` tag in `<item>` is optional. Such usage currently fails with this library:

https://github.com/gorilla/feeds/blob/6f6e20dd3953594cd869cf981fb806440685cd21/rss.go#L98

```
runtime error: invalid memory address or nil pointer dereference
```

Because of course in that case `i.Link` is nil so we can't get a `Href` from it.