### PR TITLE
feat: support multiple links in AtomFeeds struct

### DIFF
--- a/atom.go
+++ b/atom.go
@@ -67,17 +67,17 @@ type AtomLink struct {
 }
 
 type AtomFeed struct {
-	XMLName     xml.Name `xml:"feed"`
-	Xmlns       string   `xml:"xmlns,attr"`
-	Title       string   `xml:"title"`   // required
-	Id          string   `xml:"id"`      // required
-	Updated     string   `xml:"updated"` // required
-	Category    string   `xml:"category,omitempty"`
-	Icon        string   `xml:"icon,omitempty"`
-	Logo        string   `xml:"logo,omitempty"`
-	Rights      string   `xml:"rights,omitempty"` // copyright used
-	Subtitle    string   `xml:"subtitle,omitempty"`
-	Link        *AtomLink
+	XMLName     xml.Name    `xml:"feed"`
+	Xmlns       string      `xml:"xmlns,attr"`
+	Title       string      `xml:"title"`   // required
+	Id          string      `xml:"id"`      // required
+	Updated     string      `xml:"updated"` // required
+	Category    string      `xml:"category,omitempty"`
+	Icon        string      `xml:"icon,omitempty"`
+	Logo        string      `xml:"logo,omitempty"`
+	Rights      string      `xml:"rights,omitempty"` // copyright used
+	Subtitle    string      `xml:"subtitle,omitempty"`
+	Links       []*AtomLink `xml:"link,omitempty"`
 	Author      *AtomAuthor `xml:"author,omitempty"`
 	Contributor *AtomContributor
 	Entries     []*AtomEntry `xml:"entry"`
@@ -145,16 +145,23 @@ func newAtomEntry(i *Item) *AtomEntry {
 // create a new AtomFeed with a generic Feed struct's data
 func (a *Atom) AtomFeed() *AtomFeed {
 	updated := anyTimeFormat(time.RFC3339, a.Updated, a.Created)
-	link := a.Link
-	if link == nil {
-		link = &Link{}
+
+	var atomLinks []*AtomLink
+	for _, link := range a.Links {
+		atomLinks = append(atomLinks, &AtomLink{Href: link.Href, Rel: link.Rel})
 	}
+
+	var id string
+	if a.Links != nil {
+		id = a.Links[0].Href
+	}
+
 	feed := &AtomFeed{
 		Xmlns:    ns,
 		Title:    a.Title,
-		Link:     &AtomLink{Href: link.Href, Rel: link.Rel},
+		Links:    atomLinks,
 		Subtitle: a.Description,
-		Id:       link.Href,
+		Id:       id,
 		Updated:  updated,
 		Rights:   a.Copyright,
 	}

--- a/consume_test.go
+++ b/consume_test.go
@@ -191,12 +191,14 @@ var testAtomFeedXML = AtomFeed{
 	Logo:     "",
 	Rights:   "",
 	Subtitle: "",
-	Link: &AtomLink{
-		XMLName: xml.Name{Space: "", Local: "link"},
-		Href:    "",
-		Rel:     "",
-		Type:    "",
-		Length:  "",
+	Links: []*AtomLink{
+		{
+			XMLName: xml.Name{Space: "", Local: "link"},
+			Href:    "",
+			Rel:     "",
+			Type:    "",
+			Length:  "",
+		},
 	},
 	Author: &AtomAuthor{
 		XMLName:    xml.Name{Space: "", Local: "author"},

--- a/feed.go
+++ b/feed.go
@@ -41,7 +41,7 @@ type Item struct {
 
 type Feed struct {
 	Title       string
-	Link        *Link
+	Links       []*Link
 	Description string
 	Author      *Author
 	Updated     time.Time

--- a/feed_test.go
+++ b/feed_test.go
@@ -12,7 +12,8 @@ var atomOutput = `<?xml version="1.0" encoding="UTF-8"?><feed xmlns="http://www.
   <updated>2013-01-16T21:52:35-05:00</updated>
   <rights>This work is copyright © Benjamin Button</rights>
   <subtitle>discussion about tech, footie, photos</subtitle>
-  <link href="http://jmoiron.net/blog"></link>
+  <link href="http://jmoiron.net/blog" rel="alternate"></link>
+  <link href="http://jmoiron.net/feed.atom" rel="self"></link>
   <author>
     <name>Jason Moiron</name>
     <email>jmoiron@jmoiron.net</email>
@@ -199,7 +200,7 @@ func TestFeed(t *testing.T) {
 
 	feed := &Feed{
 		Title:       "jmoiron.net blog",
-		Link:        &Link{Href: "http://jmoiron.net/blog"},
+		Links:       []*Link{{Rel: "alternate", Href: "http://jmoiron.net/blog"}, {Rel: "self", Href: "http://jmoiron.net/feed.atom"}},
 		Description: "discussion about tech, footie, photos",
 		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 		Created:     now,
@@ -435,7 +436,7 @@ func TestFeedSorted(t *testing.T) {
 
 	feed := &Feed{
 		Title:       "jmoiron.net blog",
-		Link:        &Link{Href: "http://jmoiron.net/blog"},
+		Links:       []*Link{{Href: "http://jmoiron.net/blog"}},
 		Description: "discussion about tech, footie, photos",
 		Author:      &Author{Name: "Jason Moiron", Email: "jmoiron@jmoiron.net"},
 		Created:     now,
@@ -529,7 +530,7 @@ func TestFeedNil(t *testing.T) {
 
 	feed := &Feed{
 		Title:       "jmoiron.net blog",
-		Link:        nil,
+		Links:       nil,
 		Description: "discussion about tech, footie, photos",
 		Author:      nil,
 		Created:     now,

--- a/json.go
+++ b/json.go
@@ -138,8 +138,8 @@ func (f *JSON) JSONFeed() *JSONFeed {
 		Description: f.Description,
 	}
 
-	if f.Link != nil {
-		feed.HomePageUrl = f.Link.Href
+	if f.Links != nil {
+		feed.HomePageUrl = f.Links[0].Href
 	}
 	if f.Author != nil {
 		author := &JSONAuthor{

--- a/rss.go
+++ b/rss.go
@@ -146,13 +146,14 @@ func (r *Rss) RssFeed() *RssFeed {
 		image = &RssImage{Url: r.Image.Url, Title: r.Image.Title, Link: r.Image.Link, Width: r.Image.Width, Height: r.Image.Height}
 	}
 
-	var href string
-	if r.Link != nil {
-		href = r.Link.Href
+	var link string
+	if r.Links != nil {
+		link = r.Links[0].Href
 	}
+
 	channel := &RssFeed{
 		Title:          r.Title,
-		Link:           href,
+		Link:           link,
 		Description:    r.Description,
 		ManagingEditor: author,
 		PubDate:        pub,


### PR DESCRIPTION
The Atom spec allows multiple links in the Feed object, and this is required for support of things like PubSubHubbub.

Also closes #111 I believe because you can just add your own `link rel="self"` entry.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
